### PR TITLE
fix super constructor error

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,8 @@ async function getToken(username, password) {
 
 class Client extends EventEmitter {
   constructor({ token, userAgent, appId }) {
+    super();
+    
     if (!token) {
       throw new Error("Token is required.");
     }


### PR DESCRIPTION
This PR is fixing "Must call super constructor in derived class before accessing 'this' or returning from derived constructor" error by adding "super()" method in the constructor of the class.