### PR TITLE
detect checkpoint

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,6 +74,10 @@ class Client extends EventEmitter {
 		const text = await response.text();
 		const bloks = parseBloksResponse(text);
 
+		if ('error' in bloks && bloks.error.error_user_msg === "challenge_required") {
+			throw new Error('Your Instagram account is facing a checkpoint.')
+		}
+
 		if (bloks.two_factor_required) {
 			const {
 				two_factor_identifier,
@@ -132,8 +136,8 @@ class Client extends EventEmitter {
 			return;
 		}
 
-		if (bloks.login_response && bloks.login_response.logged_in_user.pk) {
-			this.userId = bloks.login_response.logged_in_user.pk_id;
+		if (bloks.login_response.logged_in_user.pk) {
+			this.userId = bloks.login_response.logged_in_user.pk;
 		}
 
 		this.token = bloks.headers?.["IG-Set-Authorization"].replace("Bearer IGT:2:", "");

--- a/src/index.js
+++ b/src/index.js
@@ -120,8 +120,8 @@ class Client extends EventEmitter {
 						const json = await response.json();
 						const header = response.headers.get('Ig-Set-Authorization');
 
-						if (json.logged_in_user.pk) {
-							self.userId = json.logged_in_user.pk;
+						if (json.logged_in_user.pk_id) {
+							self.userId = json.logged_in_user.pk_id;
 						}
 
 						clearInterval(interval);
@@ -136,8 +136,8 @@ class Client extends EventEmitter {
 			return;
 		}
 
-		if (bloks.login_response.logged_in_user.pk) {
-			this.userId = bloks.login_response.logged_in_user.pk;
+		if (bloks.login_response.logged_in_user.pk_id) {
+			this.userId = bloks.login_response.logged_in_user.pk_id;
 		}
 
 		this.token = bloks.headers?.["IG-Set-Authorization"].replace("Bearer IGT:2:", "");


### PR DESCRIPTION
I added a detection when an Instagram account encounters checkpoint.
On line 139, instead of validating whether `bloks.login_response` exists or not, I reverted it back to its original state because the error has been handled above before everything runs, and when an error occurs, we throw an error.
And on line 140, I made the usage of `pk` consistent instead of `pk_id`.