### PR TITLE
Add androidId to type definition

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -66,6 +66,7 @@ declare module "@threadsjs/threads.js" {
 		token: string;
 		userAgent: string;
 		appId: string;
+		androidId: string;
 		userId: string;
 
 		rest: RESTManager;


### PR DESCRIPTION
I noticed I needed to use androidId in some endpoints during testing. The type definition was missing this instance property.