### PR TITLE
Remove console\.log in RESTManager

### DIFF
--- a/src/managers/RESTManager.js
+++ b/src/managers/RESTManager.js
@@ -6,7 +6,6 @@ class RESTManager {
 	}
 
 	async request(url, options) {
-		console.log(this.client)
 		if (!options) {
 			options = {};
 		};


### PR DESCRIPTION
Was getting lots of logs of the client state, so I removed the line.